### PR TITLE
Implement support for year-and-month fields in timedelta_isoformat.timedelta

### DIFF
--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -18,8 +18,8 @@ class timedelta(datetime.timedelta):
             dict(
                 __repr__=cls.__repr__,
                 __str__=cls.__str__,
-                _months=int(months),
-                _years=int(years),
+                _months=months,
+                _years=years,
                 fromisoformat=cls.fromisoformat,
                 isoformat=cls.isoformat,
             ),

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -12,6 +12,8 @@ class timedelta(datetime.timedelta):
     """
 
     def __new__(cls, *args, months=0, years=0, **kwargs):
+        assert months % 1 == 0, f"unable to handle fractional months value '{months}'"
+        assert years % 1 == 0, f"unable to handle fractional years value '{years}'"
         return type(
             str(cls),
             (datetime.timedelta,),

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -11,7 +11,7 @@ class timedelta(datetime.timedelta):
     ISO8601-style parsing and formatting.
     """
 
-    def __new__(cls, *args, years=0, months=0, **kwargs):
+    def __new__(cls, *args, months=0, years=0, **kwargs):
         return type(
             str(cls),
             (datetime.timedelta,),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -47,6 +47,8 @@ valid_durations = [
     ("P0.00000000001D", timedelta(microseconds=1)),
     # decimal year-or-month values
     ("P5.0Y", timedelta(years=5)),
+    # ten-thousand-plus years
+    ("P12345Y", timedelta(years=12345)),
 ]
 
 invalid_durations = [
@@ -111,6 +113,8 @@ invalid_durations = [
     # imprecise designated date components
     ("P1.1Y", "unable to handle fractional years value '1.1'"),
     ("P0.5M", "unable to handle fractional months value '0.5'"),
+    # five-digit years
+    ("P10000-000", "unable to parse '10000-000' into date components"),
 ]
 
 # ambiguous cases

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -13,6 +13,7 @@ valid_durations = [
     ("P3DT1H", timedelta(days=3, hours=1)),
     ("P0DT1H20M", timedelta(hours=1, minutes=20)),
     ("P0Y0DT1H20M", timedelta(hours=1, minutes=20)),
+    ("P1Y5M3D", timedelta(years=1, months=5, days=3)),
     # week durations
     ("P1W", timedelta(days=7)),
     ("P3W", timedelta(days=21)),
@@ -33,6 +34,7 @@ valid_durations = [
     ("P00000004", timedelta(days=4)),
     ("P0000-00-05", timedelta(days=5)),
     ("P0000-00-00T01:02:03", timedelta(hours=1, minutes=2, seconds=3)),
+    ("P2000-06-15T00:00:30", timedelta(years=2000, months=6, days=15, seconds=30)),
     ("PT040506", timedelta(hours=4, minutes=5, seconds=6)),
     ("PT04:05:06", timedelta(hours=4, minutes=5, seconds=6)),
     ("PT00:00:00.001", timedelta(microseconds=1000)),
@@ -183,7 +185,7 @@ class TimedeltaISOFormat(unittest.TestCase):
     @unittest.skip("not currently supported")
     def test_year_month_formatting(self):
         """Formatting of timedelta objects with year-or-month attributes"""
-        year_month_timedelta = self.YearMonthTimedelta(years=1, months=6, hours=4)
+        year_month_timedelta = timedelta(years=1, months=6, hours=4)
         self.assertEqual("P1Y6MT4H", year_month_timedelta.isoformat())
         self.assertEqual(
             "YearMonthTimedelta(years=1, months=6, seconds=14400)",

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -45,6 +45,8 @@ valid_durations = [
     # matching datetime.timedelta day-to-microsecond carry precision
     ("P0.000001D", timedelta(microseconds=86400)),
     ("P0.00000000001D", timedelta(microseconds=1)),
+    # decimal year-or-month values
+    ("P5.0Y", timedelta(years=5)),
 ]
 
 invalid_durations = [
@@ -106,6 +108,9 @@ invalid_durations = [
     ("P-1DT0S", "unable to parse '-1' as a positive decimal"),
     ("P0M-2D", "unable to parse '-2' as a positive decimal"),
     ("P0DT1M-3S", "unable to parse '-3' as a positive decimal"),
+    # imprecise designated date components
+    ("P1.1Y", "unable to handle fractional years value '1.1'"),
+    ("P0.5M", "unable to handle fractional months value '0.5'"),
 ]
 
 # ambiguous cases
@@ -113,6 +118,7 @@ _ = [
     # mixed segment formats
     ("P0000-00-01T5S", "date segment format differs from time segment"),
     ("P1DT00:00:00", "date segment format differs from time segment"),
+    ("P0.5Y", "unable to handle fractional years value '0.5'"),
 ]
 
 format_expectations = [


### PR DESCRIPTION
After adding support for `months` and `years` arguments in the `timedelta_isoformat.timedelta` instance creation method, and storing those attributes on the constructed type, parsing of non-zero year-and-month values becomes possible.

Some notes about the initial implementation here:

- We are [constructing a type](https://github.com/jayaddison/timedelta-isoformat/commit/ba4e27227db3a5e7d359b53bd2a9c35e4c822b98#diff-806dec98274885ba1077ea91a104aabd0befcc7e225e0882e7f05427ba4ee959R14) (with base `timedelta_isoformat.timedelta`) during each `timedelta_isoformat.timedelta` object instance creation - this does not perform well during benchmarking tests
- ~~Non-integer `years` and `months` argument values are [typecast to `int`](https://github.com/jayaddison/timedelta-isoformat/commit/ba4e27227db3a5e7d359b53bd2a9c35e4c822b98#diff-806dec98274885ba1077ea91a104aabd0befcc7e225e0882e7f05427ba4ee959R20-R21), a process that may introduce truncation or loss-of-precision.  Constructing a `datetime.timedelta` with a sub-microsecond value acts similarly in Py3.9 -- but sub-day values are well-supported (fractional days are converted into seconds).~~ (edit: this is outdated; typecasting these fields to `int` has been replaced by a check to see whether their values leave a remainder when divided-by-one))
- Nice-to-have: it might be possible to improve consistency with existing `datetime.timedelta` field accessors by marking `years` and `months` as read-only -- instead, the class attribute names used to hold `years` and `months` arguments are prefixed by an underscore to indicate that they're internal/private