### PR TITLE
Allow parsing duration strings that contain empty time segments

### DIFF
--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -125,7 +125,6 @@ class timedelta(datetime.timedelta):
         an attempt is made to parse the segment as a fixed-length date or time.
         """
         assert duration.startswith("P"), "durations must begin with the character 'P'"
-        assert not duration.endswith("T"), "no measurements found in time segment"
 
         if duration[-1].isupper():
             yield from timedelta._fromdesignators(duration[1:])

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -47,7 +47,12 @@ valid_durations = [
 invalid_durations = [
     # incomplete strings
     ("", "durations must begin with the character 'P'"),
+    ("T", "durations must begin with the character 'P'"),
     ("P", "no measurements found"),
+    ("PT", "no measurements found"),
+    ("PPT", "unexpected character 'P'"),
+    ("PTT", "unexpected character 'T'"),
+    ("PTP", "unexpected character 'P'"),
     # incomplete measurements
     ("P0YD", "unable to parse '' as a positive decimal"),
     # repeated designators

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -48,10 +48,6 @@ invalid_durations = [
     # incomplete strings
     ("", "durations must begin with the character 'P'"),
     ("P", "no measurements found"),
-    ("P0DT", "no measurements found in time segment"),
-    ("P1DT", "no measurements found in time segment"),
-    ("P0Y5MT", "no measurements found in time segment"),
-    ("P0000001T", "no measurements found in time segment"),
     # incomplete measurements
     ("P0YD", "unable to parse '' as a positive decimal"),
     # repeated designators


### PR DESCRIPTION
Resolves #9.