### PR TITLE
Formatting: refuse to provide ISO formatting for negative 'timedelta' instances

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ A variety of ISO 8601 duration parsers exist across a range of programming langu
 Some of the significant design decisions made within this library are:
 
 * Values in parsed duration strings must be zero-or-greater (``PT1H`` is considered valid; ``P-2D`` is not)
+* Time deltas must be zero-or-greater to be formatted as ISO durations  (``timedelta(hours=-1, seconds=5200)`` can be formatted; ``timedelta(hours=-1, seconds=2400)`` cannot)
 * Empty time segments at the end of duration strings are allowed (``P1DT`` is considered valid)
 * Measurement limits are checked within date/time segments (``PT20:59:01`` is within limits; ``PT20:60:01`` is not)
 * Measurement values are parsed into floating-point values (at the time of writing, precise procedural algorithms to parse base-ten strings into integers for large inputs are not practical -- or not widely known)

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ A variety of ISO 8601 duration parsers exist across a range of programming langu
 Some of the significant design decisions made within this library are:
 
 * Values in parsed duration strings must be zero-or-greater (``PT1H`` is considered valid; ``P-2D`` is not)
-* Time deltas must be zero-or-greater to be formatted as ISO durations  (``timedelta(hours=-1, seconds=5200)`` can be formatted; ``timedelta(hours=-1, seconds=2400)`` cannot)
+* Time deltas must be zero-or-greater to be formatted as ISO durations (``timedelta(hours=-1, seconds=5200)`` can be formatted; ``timedelta(hours=-1, seconds=2400)`` cannot)
 * Empty time segments at the end of duration strings are allowed (``P1DT`` is considered valid)
 * Measurement limits are checked within date/time segments (``PT20:59:01`` is within limits; ``PT20:60:01`` is not)
 * Measurement values are parsed into floating-point values (at the time of writing, precise procedural algorithms to parse base-ten strings into integers for large inputs are not practical -- or not widely known)

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -149,6 +149,7 @@ class timedelta(datetime.timedelta):
 
     def isoformat(self) -> str:
         """Produce an ISO8601-style representation of this :py:class:`timedelta`"""
+        assert self >= timedelta(0), f"cannot produce ISO format for negative {self!r}"
         if not self:
             return "P0D"
 

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -157,8 +157,15 @@ format_expectations = [
     (timedelta(days=12, hours=31, seconds=500), "PT1148900S"),
     (timedelta(days=12, hours=32), "PT320H"),
     (timedelta(seconds=86400), "P1D"),
+    (timedelta(days=-1, hours=25), "PT1H"),
+    (timedelta(seconds=-1, microseconds=1000000), "P0D"),
 ]
 
+formatting_unavailable = [
+    timedelta(hours=-1),
+    timedelta(seconds=-1),
+    timedelta(seconds=-1, microseconds=999999),
+]
 
 class TimedeltaISOFormat(unittest.TestCase):
     """Functional testing for :class:`timedelta_isoformat.timedelta`"""
@@ -258,3 +265,10 @@ class TimedeltaISOFormat(unittest.TestCase):
         for sample_timedelta, expected_format in format_expectations:
             with self.subTest(sample_timedelta=sample_timedelta):
                 self.assertEqual(expected_format, sample_timedelta.isoformat())
+
+    @unittest.skipIf(sys.flags.optimize, "Some optimizations assume valid input")
+    def test_formatting_unavailable(self) -> None:
+        """Durations that cannot be formatted as-is"""
+        for sample_timedelta in formatting_unavailable:
+            with self.assertRaises(AssertionError):
+                sample_timedelta.isoformat()

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -167,6 +167,7 @@ formatting_unavailable = [
     timedelta(seconds=-1, microseconds=999999),
 ]
 
+
 class TimedeltaISOFormat(unittest.TestCase):
     """Functional testing for :class:`timedelta_isoformat.timedelta`"""
 


### PR DESCRIPTION
Resolves #8.